### PR TITLE
docker: surface April 2026 security hardening flags

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,6 +42,14 @@ CMD ["./authorizer \\\n\
   --enable-graphql-introspection=\"${ENABLE_GRAPHQL_INTROSPECTION:-true}\" \\\n\
   --app-cookie-secure=\"${APP_COOKIE_SECURE:-true}\" \\\n\
   --admin-cookie-secure=\"${ADMIN_COOKIE_SECURE:-true}\" \\\n\
+  --trusted-proxies=\"${TRUSTED_PROXIES}\" \\\n\
+  --refresh-token-expires-in=\"${REFRESH_TOKEN_EXPIRES_IN:-2592000}\" \\\n\
+  --enable-hsts=\"${ENABLE_HSTS:-false}\" \\\n\
+  --disable-csp=\"${DISABLE_CSP:-false}\" \\\n\
+  --graphql-max-complexity=\"${GRAPHQL_MAX_COMPLEXITY:-300}\" \\\n\
+  --graphql-max-depth=\"${GRAPHQL_MAX_DEPTH:-15}\" \\\n\
+  --graphql-max-aliases=\"${GRAPHQL_MAX_ALIASES:-30}\" \\\n\
+  --graphql-max-body-bytes=\"${GRAPHQL_MAX_BODY_BYTES:-1048576}\" \\\n\
   --database-name=\"${DATABASE_NAME}\" \\\n\
   --database-username=\"${DATABASE_USERNAME}\" \\\n\
   --database-password=\"${DATABASE_PASSWORD}\" \\\n\


### PR DESCRIPTION
## Summary
Adds the new CLI flags introduced by authorizerdev/authorizer PRs #582–#590 to the Railway entrypoint so operators can configure them via Railway environment variables.

New env vars wired through:
- \`TRUSTED_PROXIES\` → \`--trusted-proxies\` (CIDRs of trusted reverse proxies; **required** when behind Railway's edge proxy or per-IP rate limiting will key on the proxy IP)
- \`REFRESH_TOKEN_EXPIRES_IN\` → \`--refresh-token-expires-in\` (default 2592000s / 30 days)
- \`ENABLE_HSTS\` → \`--enable-hsts\` (default false; only safe behind TLS)
- \`DISABLE_CSP\` → \`--disable-csp\` (default false)
- \`GRAPHQL_MAX_{COMPLEXITY,DEPTH,ALIASES,BODY_BYTES}\` → the \`--graphql-max-*\` DoS limits

## Heads-up for users upgrading
The new authorizer binary requires \`--admin-secret\` to be **non-empty** at startup. The \`ADMIN_SECRET\` env var was already documented as required, but Railway deployments that left it unset will now fail-fast instead of running with the old insecure \`"password"\` default. See [security docs](https://docs.authorizer.dev/core/security#admin-authentication).

## Test plan
- [ ] Deploy on Railway with \`TRUSTED_PROXIES\` set to Railway's proxy CIDR
- [ ] Confirm rate-limit metrics show real client IPs not the Railway edge IP
- [ ] Confirm \`/metrics\` shows \`authorizer_graphql_limit_rejections_total\` if exercised